### PR TITLE
default scraped chats to public

### DIFF
--- a/packages/scripts/src/scrape-groupchats/groupchat.ts
+++ b/packages/scripts/src/scrape-groupchats/groupchat.ts
@@ -4,4 +4,7 @@ export type Groupchat = {
   showUnauthenticated?: boolean;
 };
 
-export type ProcessedGroupchat = Groupchat & {platform: string};
+export type ProcessedGroupchat = Groupchat & {
+  platform: string;
+  showUnauthenticated: boolean;
+};

--- a/packages/scripts/src/scrape-groupchats/post-process.ts
+++ b/packages/scripts/src/scrape-groupchats/post-process.ts
@@ -65,7 +65,11 @@ export const postProcess = async (
     // We might scrape things like &amp;
     groupchat.name = decode(groupchat.name);
 
-    validPlatformGroupchats.push({...groupchat, platform});
+    validPlatformGroupchats.push({
+      ...groupchat,
+      platform,
+      showUnauthenticated: true,
+    });
   }
 
   return validPlatformGroupchats;


### PR DESCRIPTION
Since all links scraped are already public, we mark them as public to show up in search