### PR TITLE
fix: domain finder

### DIFF
--- a/packages/scripts/src/scrape-groupchats/post-process.ts
+++ b/packages/scripts/src/scrape-groupchats/post-process.ts
@@ -4,7 +4,7 @@ import {handleBitLy} from './platform-handlers/bit-ly.js';
 import {handleLinkTree} from './platform-handlers/link-tree.js';
 
 const platformDomainFinder =
-  /https?:\/\/.*?(facebook.com|instagram.com|chat.whatsapp.com|discord.gg|discord.com|t.me).*$/i;
+  /https?:\/\/(?:.*?\.)?(facebook\.com|instagram\.com|chat\.whatsapp\.com|discord\.gg|discord\.com|t\.me)(?:\/.*)?$/i;
 
 const domainMap: Record<string, string> = {
   'facebook.com': 'facebook',


### PR DESCRIPTION
Fixes: https://github.com/Yes-Theory-Fam/yestheory.family/security/code-scanning/1

Due to a bad regex, it was previously possible that bad URLs could have been scraped (for example with domains: chatswhatsappweb.com or discord.gg.evil).

The new regex forces anything between the URL scheme and matched domain to be a subdomain and anything after the matched domain to be a path and correctly escapes the period character in the domains to avoid matching other characters.